### PR TITLE
Remove hint for using Ansible 2.2.1 because README says 2.4 is needed anyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Supports the following Operating Systems:
 
 This role requires Ansible 2.4 or higher. Requirements are listed in the metadata file.
 
-If you rely on privileage escalation (e.g. `become: true`) with this role, you will need Ansible 2.2.1 or higher to take advantage of this issue being fixed: <https://github.com/ansible/ansible/issues/17490>
-
 ## Role Variables
 
 For more information about the variables many can be found <https://docs.docker.com/engine/reference/commandline/dockerd/>


### PR DESCRIPTION
As far as I understand, the requirement of Ansible 2.4 does not allow for an Ansible version of 2.2.0 or lower (where the bug still exists).