### PR TITLE
Remove link to example folder. It does not exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ Install docker with AUFS. This is recommended for production deployment on Ubunt
       docker_storage_driver: aufs
 ```
 
-Please see [examples/](examples/) folder for more examples.
-
 ## License
 
 Apache 2.0


### PR DESCRIPTION
As the title says: There is no examples folder to link to.